### PR TITLE
Update and fix the Recalc strategy

### DIFF
--- a/dfaasagent/agent/config/config.go
+++ b/dfaasagent/agent/config/config.go
@@ -52,7 +52,7 @@ type Configuration struct {
 	BootstrapNodesFile string `mapstructure:"AGENT_BOOTSTRAP_NODES_FILE"`
 
 	// If true, agent's initialization loops until all bootstrap nodes can be
-    // contacted.
+	// contacted.
 	BootstrapForce bool `mapstructure:"AGENT_BOOTSTRAP_FORCE"`
 
 	// Unique string used for grouping peers for discovery.

--- a/dfaasagent/agent/discovery/kademlia/kademlia.go
+++ b/dfaasagent/agent/discovery/kademlia/kademlia.go
@@ -83,7 +83,7 @@ func Initialize(ctx context.Context, p2pHost host.Host, bootstrapConfig Bootstra
 			for {
 				logger.Debugf("Connecting to bootstrap node: %s", peerAddr.String())
 				err := p2pHost.Connect(ctx, *peerInfo)
-                if err == nil {
+				if err == nil {
 					logger.Infof("Connected to bootstrap node %s", peerInfo.String())
 					return
 				}

--- a/dfaasagent/agent/httpserver/httpserver.go
+++ b/dfaasagent/agent/httpserver/httpserver.go
@@ -32,6 +32,11 @@ var StrategySuccessIterations = promauto.NewCounter(prometheus.CounterOpts{
 	Help: "The total number of successfully strategy iterations.",
 })
 
+var StrategyIterationDuration = prometheus.NewGauge(prometheus.GaugeOpts{
+    Name: "dfaas_agent_strategy_iteration_duration_seconds",
+    Help: "Execution duration of a successfully strategy iteration in seconds",
+})
+
 // Initialize initializes this package (sets some vars, etc...)
 func Initialize(config config.Configuration) {
 	_config = config
@@ -50,6 +55,7 @@ func RunHttpServer() error {
 	customRegistry := prometheus.NewRegistry()
 
 	customRegistry.MustRegister(StrategySuccessIterations)
+	customRegistry.MustRegister(StrategyIterationDuration)
 
 	http.HandleFunc("/healthz", healthzHandler)
 	http.Handle("/metrics", promhttp.HandlerFor(customRegistry, promhttp.HandlerOpts{}))

--- a/dfaasagent/agent/httpserver/httpserver.go
+++ b/dfaasagent/agent/httpserver/httpserver.go
@@ -27,9 +27,9 @@ import (
 var _config config.Configuration
 var _forecasterClient forecaster.Client
 
-var NmsSuccessIterations = promauto.NewCounter(prometheus.CounterOpts{
-	Name: "dfaas_agent_nms_success_iterations",
-	Help: "The total number of successfully NodeMarginStrategy iterations.",
+var StrategySuccessIterations = promauto.NewCounter(prometheus.CounterOpts{
+	Name: "dfaas_agent_strategy_iterations",
+	Help: "The total number of successfully strategy iterations.",
 })
 
 // Initialize initializes this package (sets some vars, etc...)
@@ -49,7 +49,7 @@ func RunHttpServer() error {
 	// Expose to Prometheus only custom metrics by creating a new registry.
 	customRegistry := prometheus.NewRegistry()
 
-	customRegistry.MustRegister(NmsSuccessIterations)
+	customRegistry.MustRegister(StrategySuccessIterations)
 
 	http.HandleFunc("/healthz", healthzHandler)
 	http.Handle("/metrics", promhttp.HandlerFor(customRegistry, promhttp.HandlerOpts{}))

--- a/dfaasagent/agent/infogath/offuncs/offuncs.go
+++ b/dfaasagent/agent/infogath/offuncs/offuncs.go
@@ -126,13 +126,13 @@ type Client struct {
 }
 
 // NewClient returns a new Client.
-func NewClient(hostname string, port uint, username, password string) (*Client, error) {
+func NewClient(hostname string, port uint, username, password string) *Client {
 	return &Client{
 		hostname: hostname,
 		port:     port,
 		username: username,
 		password: password,
-	}, nil
+	}
 }
 
 // doFuncsRequest gets info about functions from "/system/functions" endpoint.

--- a/dfaasagent/agent/loadbalancer/dbglogging.go
+++ b/dfaasagent/agent/loadbalancer/dbglogging.go
@@ -206,31 +206,6 @@ func debugPromRAMusagePerFunction(timeSpan time.Duration, data map[string]float6
 	logger.Debug(b.String())
 }
 
-func debugHAProxyUserRates(data map[string]float64) {
-	if !logging.GetDebugMode() {
-		return
-	}
-
-	keys := make([]string, 0, len(data))
-	for k := range data {
-		keys = append(keys, k)
-	}
-
-	sort.Strings(keys)
-
-	var b strings.Builder
-	b.WriteString("Invocation rates of requests from users only (calculated from HAProxy stick-table):")
-	if len(keys) == 0 {
-		b.WriteString("empty")
-	} else {
-		for _, funcName := range keys {
-			b.WriteString("\n")
-			b.WriteString(fmt.Sprintf("  - FUNC %s: %.2f req/s\n", funcName, data[funcName]))
-		}
-	}
-	logging.Logger().Debug(b.String())
-}
-
 func debugFuncs(data map[string]uint) {
 	if !logging.GetDebugMode() {
 		return
@@ -248,7 +223,7 @@ func debugFuncs(data map[string]uint) {
 	if len(keys) > 0 {
 		b.WriteString(" (limit req/s) ")
 		for _, funcName := range keys {
-			b.WriteString(fmt.Sprintf("%q (%s) ", funcName, data[funcName]))
+			b.WriteString(fmt.Sprintf("%q (%d) ", funcName, data[funcName]))
 		}
 	}
 	logging.Logger().Debug(b.String())
@@ -363,7 +338,7 @@ func debugStickTable(stName string, stContent map[string]*hasock.STEntry) {
 		b.WriteString("\n")
 		for _, key := range clients {
 			stEntry := stContent[key]
-			b.WriteString(fmt.Sprintf("  - key=%s: cnt=%d rate=%d\n", key, stEntry.HTTPReqCnt, stEntry.HTTPReqRate))
+			b.WriteString(fmt.Sprintf("  - key=%s cnt=%d rate=%d\n", key, stEntry.HTTPReqCnt, stEntry.HTTPReqRate))
 		}
 	}
 	logging.Logger().Debug(b.String())

--- a/dfaasagent/agent/loadbalancer/dbglogging.go
+++ b/dfaasagent/agent/loadbalancer/dbglogging.go
@@ -211,8 +211,6 @@ func debugHAProxyUserRates(data map[string]float64) {
 		return
 	}
 
-	logger := logging.Logger()
-
 	keys := make([]string, 0, len(data))
 	for k := range data {
 		keys = append(keys, k)
@@ -221,11 +219,16 @@ func debugHAProxyUserRates(data map[string]float64) {
 	sort.Strings(keys)
 
 	var b strings.Builder
-	b.WriteString("Invocation rates of requests from users only (calculated from HAProxy stick-table):\n")
-	for _, funcName := range keys {
-		b.WriteString(fmt.Sprintf("  - FUNC %s: %.2f req/s\n", funcName, data[funcName]))
+	b.WriteString("Invocation rates of requests from users only (calculated from HAProxy stick-table):")
+	if len(keys) == 0 {
+		b.WriteString("empty")
+	} else {
+		for _, funcName := range keys {
+			b.WriteString("\n")
+			b.WriteString(fmt.Sprintf("  - FUNC %s: %.2f req/s\n", funcName, data[funcName]))
+		}
 	}
-	logger.Debug(b.String())
+	logging.Logger().Debug(b.String())
 }
 
 func debugFuncs(data map[string]uint) {
@@ -266,7 +269,14 @@ func debugNodesTblContent(entries map[string]*nodestbl.EntryRecalc) {
 	sort.Strings(nodeIDs)
 
 	var b strings.Builder
-	b.WriteString("Content of nodestbl:\n")
+	b.WriteString("Content of nodestbl:")
+	if len(nodeIDs) == 0 {
+		b.WriteString("empty")
+		logger.Debug(b.String())
+		return
+	}
+
+	b.WriteString("\n")
 	for _, nodeID := range nodeIDs {
 		entry := entries[nodeID]
 
@@ -347,15 +357,15 @@ func debugStickTable(stName string, stContent map[string]*hasock.STEntry) {
 
 	var b strings.Builder
 	b.WriteString(fmt.Sprintf("HAProxy stick-table %q content:", stName))
-    if len(clients) == 0 {
-        b.WriteString(" empty")
-    } else {
-        b.WriteString("\n")
-        for _, key := range clients {
-            stEntry := stContent[key]
-            b.WriteString(fmt.Sprintf("  - key=%s: cnt=%d rate=%d\n", key, stEntry.HTTPReqCnt, stEntry.HTTPReqRate))
-        }
-    }
+	if len(clients) == 0 {
+		b.WriteString(" empty")
+	} else {
+		b.WriteString("\n")
+		for _, key := range clients {
+			stEntry := stContent[key]
+			b.WriteString(fmt.Sprintf("  - key=%s: cnt=%d rate=%d\n", key, stEntry.HTTPReqCnt, stEntry.HTTPReqRate))
+		}
+	}
 	logging.Logger().Debug(b.String())
 }
 

--- a/dfaasagent/agent/loadbalancer/dbglogging.go
+++ b/dfaasagent/agent/loadbalancer/dbglogging.go
@@ -241,11 +241,11 @@ func debugFuncs(data map[string]uint) {
 	sort.Strings(keys)
 
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("Available functions: %d functions", len(keys)))
+	b.WriteString(fmt.Sprintf("Available functions: %d", len(keys)))
 	if len(keys) > 0 {
-		b.WriteString("\n")
+		b.WriteString(" (limit req/s) ")
 		for _, funcName := range keys {
-			b.WriteString(fmt.Sprintf("  - Function %q (limit %d req/s)\n", funcName, data[funcName]))
+			b.WriteString(fmt.Sprintf("%q (%s) ", funcName, data[funcName]))
 		}
 	}
 	logging.Logger().Debug(b.String())
@@ -346,11 +346,16 @@ func debugStickTable(stName string, stContent map[string]*hasock.STEntry) {
 	sort.Strings(clients)
 
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("Stick-table %q content:\n", stName))
-	for _, key := range clients {
-		stEntry := stContent[key]
-		b.WriteString(fmt.Sprintf("  - key=%s: cnt=%d rate=%d\n", key, stEntry.HTTPReqCnt, stEntry.HTTPReqRate))
-	}
+	b.WriteString(fmt.Sprintf("HAProxy stick-table %q content:", stName))
+    if len(clients) == 0 {
+        b.WriteString(" empty")
+    } else {
+        b.WriteString("\n")
+        for _, key := range clients {
+            stEntry := stContent[key]
+            b.WriteString(fmt.Sprintf("  - key=%s: cnt=%d rate=%d\n", key, stEntry.HTTPReqCnt, stEntry.HTTPReqRate))
+        }
+    }
 	logging.Logger().Debug(b.String())
 }
 

--- a/dfaasagent/agent/loadbalancer/haproxycfgrecalc.tmpl
+++ b/dfaasagent/agent/loadbalancer/haproxycfgrecalc.tmpl
@@ -21,7 +21,7 @@ defaults
   timeout connect 60s
   timeout server 60s
 
-{{/* Warning: The order of plain comments (“#”) in the HAProxy config is not
+{{/* Warning: The order of plain comments ("#") in the HAProxy config is not
 preserved. From this point on, the configuration is managed by the DFaaS agent.
 */}}
 

--- a/dfaasagent/agent/loadbalancer/haproxycfgrecalc.tmpl
+++ b/dfaasagent/agent/loadbalancer/haproxycfgrecalc.tmpl
@@ -21,43 +21,33 @@ defaults
   timeout connect 60s
   timeout server 60s
 
-{{/* Warning: The order of plain comments ("#") in the HAProxy config is not
-preserved. From this point on, the configuration is managed by the DFaaS agent.
-*/}}
-
-{{/* #################### STICK-TABLES #################### */ -}}
-
 {{range $funcName, $func := .Functions -}}
-{{/* Stick-Table for specific function invocations:
-    - not denied
-    - from users only
-    - only one row, for all clients
-The size is set to 10, but setting it to 1 should be already enough. */ -}}
+# Stick table for invocations of function {{$funcName}} from users, not from
+# other DFaaS nodes. We just use one row for all clients. Denied requests are
+# not counted here.
+#
+# Among all stick tables, this is the only one used by the DFaaS agent to
+# calculate forwarding weights.
 backend st_users_func_{{$funcName}}
-    stick-table type integer size 10 expire {{$.StrRecalc}} store http_req_cnt,http_req_rate(1s)
-{{/* Stick-Table for specific function invocations:
-    - not denied
-    - to local OpenFaaS instance only
-    - only one row, for all clients
-The size is set to 10, but setting it t!bgo 1 should be already enough. */ -}}
+    stick-table type integer size 10 expire {{$.SecsRecalc}}s store http_req_cnt,http_req_rate(1s)
+
+# Stick table for invocations of functions {{$funcName}} from all sources (users
+# and other DFaaS nodes). Same structure as st_users_func{{$funcName}}.
 backend st_local_func_{{$funcName}}
-    stick-table type integer size 10 expire {{$.StrRecalc}} store http_req_cnt,http_req_rate(1s)
+    stick-table type integer size 10 expire {{$.SecsRecalc}}s store http_req_cnt,http_req_rate(1s)
 
-{{/* [NEW] Stick-Table for counting request from others agents:
-    - One table for each tuple (node, function).
-    - Key is destination port (80).
-    - Counting request num and rate.
-    - RecalTime for expiring why LimitIn are updated every "RecalPeriod" time.
-    - Count number of requests and check rate for periods of 1 sec.
-*/ -}}
 {{range $nodeID, $_ := $func.LimitsIn -}}
+# Stick table for invocation of function {{$funcName}} from the DFaaS node with
+# id {{$nodeID}}.
+#
+# We use destination port (80) as key and we count requests num and rate.
+# RecalTime for expiring why LimitIn are updated every "RecalPeriod" time. Count
+# number of requests and check rate for periods of 1 sec.
 backend st_other_node_{{$funcName}}_{{$nodeID}}
-    stick-table type integer size 10 expire {{$.StrRecalc}} store http_req_cnt,http_req_rate(1s)
+    stick-table type integer size 10 expire {{$.SecsRecalc}}s store http_req_cnt,http_req_rate(1s)
 {{end}}
 
 {{end}}
-
-{{/* #################### FRONTEND #################### */ -}}
 
 frontend fe_main
     bind *:80
@@ -179,100 +169,93 @@ frontend fe_main
 
     {{end}}
 
+# Note: for all backend we enable HTTP health checks and HTTP connection closing
+# on the server side. This provides the lowest latency on the client side (slow
+# network) and the fastest session reuse on the server side to save server
+# resources.
+
 # Backend for simple 200 OK responses.
 backend be_ok
     http-request return status 200 content-type "text/plain" string "This is a DFaaS node. Call a function with /function/<funcname>\n"
 
 # Backend for health check.
 backend be_healthz
-    # Perform HTTP health checks.
     option httpchk GET /healthz
-
-    # Enable HTTP connection closing on the server side. This provides the
-    # lowest latency on the client side (slow network) and the fastest session
-    # reuse on the server side to save server resources.
     option http-server-close
-
     server healthz dfaas-agent:80 check
 
-{{/* #################### BACKEND FOR MANAGING OPENFAAS FUNCTIONS #################### */ -}}
-
+# Backend for OpenFaaS Administrative API (/system/functions)
 backend be_system_funcs
-    {{/* Perform HTTP health checks */ -}}
     option httpchk GET /
-    {{/* Enable HTTP connection closing on the server side. This provides the lowest latency
-    on the client side (slow network) and the fastest session reuse on the server side
-    to save server resources */ -}}
     option http-server-close
     server system_funcs {{.OpenFaaSHost}}:{{.OpenFaaSPort}} check
 
-{{/* #################### BACKEND FOR SELF OPENFAAS INSTANCE #################### */ -}}
-
+# Backend for the local OpenFaaS instance. Requests (functions) arriving here
+# will be handled locally.
+#
+# Requests may originate directly from a client or from another DFaaS node. We
+# differentiate these cases using the DFaaS-Node-ID header.
+#
+# When the OpenFaaS instance responds, we add an X-Server header containing the
+# node's IP address and a DFaaS-Node-ID header with the agent's ID (libp2p ID).
+# This allows clients to identify which DFaaS node processed the request.
 backend be_myself
-    {{/* Perform HTTP health checks (with the OPTIONS method by default) */ -}}
     option httpchk GET /
-    {{/* Enable insertion of the X-Forwarded-For header to requests sent to servers */ -}}
-    option forwardfor
-    {{/* Enable HTTP connection closing on the server side. This provides the lowest latency
-    on the client side (slow network) and the fastest session reuse on the server side
-    to save server resources */ -}}
     option http-server-close
 
-    {{/* Add DFaaS-Node-ID header (in any case) */ -}}
+    # Automatically add the X-Forwarded-For header to let know the local
+    # OpenFaaS instance of the original client's IP address.
+    option forwardfor
+
+    # Always include the DFaaS-Node-ID header containing the node's ID.
     http-request add-header DFaaS-Node-ID {{.MyNodeID}}
 
-    {{/* [NEW] Replicated ACLs for visibility. */}}
-    acl has_nodeid_hdr var(req.hdrcnt_nodeid),add(0) gt 0 {{- /* The ",add(0)" is needed here, for some reason (maybe haproxy bug? like int/str conversion or something... if you remove it there will be problems!!!) */}}
+    # Replicate here some ACLs from the frontend. They will be used to track
+    # statistics.
+    acl has_nodeid_hdr var(req.hdrcnt_nodeid),add(0) gt 0
     {{range $nodeID, $_ := $.Nodes}}
     acl is_node_{{$nodeID}} req.hdr(DFaaS-Node-ID) -m str {{$nodeID}}
     {{end}}
 
+    # For each function, record statistics in a dedicated stick table named
+    # st_local_func_<funcname>. Additionally, at the neighbor node level, track
+    # each function/node pair in a dedicated stick table named
+    # st_other_node_<funcname>_<nodeid>.
     {{range $funcName, $func := .Functions -}}
     acl is_func_{{$funcName}} path_beg /function/{{$funcName}}
-    {{/* Track all clients (this works because dst_port is 80 for every possible request) */ -}}
-    http-request track-sc2 dst_port table st_local_func_{{$funcName}} if is_func_{{$funcName}} {{- /* Using Sticky-Counter #2 */}}
-    
-    {{/* [NEW] ########### TRACKING WITH STICK TABLES FWD MESSAGED ########## */ -}}
-    {{/* How it works?
-            - If a message has a header "DFaaSNode..." it comes from another DFaaS node, indeed the message
-              has been forwarded.
-            - If a message has been forwarded from another node, increment row in a specific stick table.
-        If the above condition are satisfied increment specific table.
-    */ -}}
+    http-request track-sc2 dst_port table st_local_func_{{$funcName}} if is_func_{{$funcName}}
+
     {{range $nodeID, $_ := $func.LimitsIn -}}
-    http-request track-sc0 dst_port table st_other_node_{{$funcName}}_{{$nodeID}} if is_func_{{$funcName}} has_nodeid_hdr is_node_{{$nodeID}} {{/*is_hdr_nodeID_known*/ -}} {{- /* Using Sticky-Counter #0 */}}
+    http-request track-sc0 dst_port table st_other_node_{{$funcName}}_{{$nodeID}} if is_func_{{$funcName}} has_nodeid_hdr is_node_{{$nodeID}}
     {{end}}
     
     {{end}}
 
-    # Add X-Server (IP:port) and DFaaS-Node-ID (libp2p's ID) headers to response
-    # to let clients know which DFaaS server served the request.
     http-response set-header X-Server %s
     http-response set-header DFaaS-Node-ID {{$.MyNodeID}}
 
     server {{$.NodeIP}} {{.OpenFaaSHost}}:{{.OpenFaaSPort}} check
 
-{{/* #################### BACKEND FOR OTHER NODES' HAPROXIES #################### */ -}}
-
 {{range $funcName, $func := .Functions -}}
+# Backend responsible for forwarding incoming user requests to other DFaaS
+# nodes. This backend is specific to the {{$funcName}} function.
+#
+# Forwarding follows a round-robin method with custom weights.
+#
+# As with the be_myself backend, the reply will have X-Server with the DFaaS
+# agent IP address that served the requests and its node ID in DFaaS-Node-ID
+# header.
+#
+# Neighbor nodes with a weight of 0 will be excluded.
 backend be_others_func_{{$funcName}}
-    {{/* Enable load-balancing using custom weights */ -}}
-    balance roundrobin
-
-    {{/* Perform HTTP health checks (with the OPTIONS method by default) */ -}}
     option httpchk GET /
-    {{/* Enable insertion of the X-Forwarded-For header to requests sent to servers */ -}}
     option forwardfor
-    {{/* Enable HTTP connection closing on the server side. This provides the lowest latency
-    on the client side (slow network) and the fastest session reuse on the server side
-    to save server resources */ -}}
     option http-server-close
 
-    {{/* Add DFaaS-Node-ID header (in any case) */ -}}
-    http-request add-header DFaaS-Node-ID {{$.MyNodeID}}
+    balance roundrobin
 
-    {{/* Add X-Server header to response to know which server served the request */ -}}
     http-response set-header X-Server %s
+    http-request add-header DFaaS-Node-ID {{$.MyNodeID}}
 
     {{range $nodeID, $weight := $func.Weights -}}
     {{if (gt $weight 0) -}}
@@ -281,11 +264,14 @@ backend be_others_func_{{$funcName}}
     {{end}}
 {{end}}
 
-{{/* [NEW] #################### BACKEND FOR DENY EXCEEDING LIMIT IN REQUESTS #################### */ -}}
-{{/* Note: It could be divided in alla specific be for nodes and functions and returns a specific error message */ -}}
-{{/* 503 (Service Unavailable) status code can be used.
-    At the moment 429 has been used for test purpose. */}}
 # Backend for deny exceeding limit in requests.
+#
+# As with the be_myself backend, the reply will have X-Server with the local
+# DFaaS node IP and its node IS in DFaaS-Node-ID.
+#
+# TODO: It could be divided in alla specific be for nodes and functions and
+# returns a specific error message.
 backend be_limitInExceeds
+    http-response set-header X-Server {{$.NodeIP}}
     http-response set-header DFaaS-Node-ID {{$.MyNodeID}}
     http-request deny deny_status 429

--- a/dfaasagent/agent/loadbalancer/haproxycfgrecalc.tmpl
+++ b/dfaasagent/agent/loadbalancer/haproxycfgrecalc.tmpl
@@ -1,4 +1,5 @@
 # HAProxy configuration file updated by DFaaS agent on {{.Now}}
+# DFaaS Agent running with Recalc strategy.
 
 # See k8s/charts/values-haproxy.yaml for more information about global,
 # userlist, defaults and program sections.
@@ -20,8 +21,9 @@ defaults
   timeout connect 60s
   timeout server 60s
 
-# The configuration is generated and changed by the DFaaS agent from this point
-# on.
+{{/* Warning: The order of plain comments (“#”) in the HAProxy config is not
+preserved. From this point on, the configuration is managed by the DFaaS agent.
+*/}}
 
 {{/* #################### STICK-TABLES #################### */ -}}
 
@@ -283,5 +285,7 @@ backend be_others_func_{{$funcName}}
 {{/* Note: It could be divided in alla specific be for nodes and functions and returns a specific error message */ -}}
 {{/* 503 (Service Unavailable) status code can be used.
     At the moment 429 has been used for test purpose. */}}
+# Backend for deny exceeding limit in requests.
 backend be_limitInExceeds
+    http-response set-header DFaaS-Node-ID {{$.MyNodeID}}
     http-request deny deny_status 429

--- a/dfaasagent/agent/loadbalancer/loadbalancer.go
+++ b/dfaasagent/agent/loadbalancer/loadbalancer.go
@@ -3,8 +3,13 @@
 // This file is licensed under the AGPL v3.0 or later license. See LICENSE and
 // AUTHORS file for more information.
 
-// This package handles the main operational logic of the DFaaSAgent
-// application.
+// The loadbalancer package handles the main operational logic of the DFaaS
+// agent. Using different (and selectable) strategies, it dynamically configures
+// HAProxy at regular intervals and determines the node’s workload distribution.
+//
+// The package is implemented using a modular approach: a new strategy can be
+// added by defining a factory type and a strategy type. For more details, see
+// the strategyfactory.go file.
 package loadbalancer
 
 import (
@@ -18,32 +23,34 @@ import (
 	"github.com/unimib-datAI/dfaas/dfaasagent/agent/logging"
 )
 
-//////////////////// MAIN PRIVATE VARS AND INIT FUNCTION ////////////////////
+// For a running agent, only one strategy can be active at a time. These
+// variables hold the necessary objects to run the strategy, following the
+// singleton pattern.
+var (
+	_p2pHost host.Host
 
-var _p2pHost host.Host
-var _config config.Configuration
+	// Configuration given by the environment.
+	_config config.Configuration
 
-// Strategy factory which manages the creation of the strategy instance
-var _strategyFactory strategyFactory
+	// Strategy factory which manages the creation of the strategy instance.
+	_strategyFactory strategyFactory
 
-// Lock used to manage the singleton strategy instance
-var _lock *sync.Mutex
+	// Lock used to manage the singleton strategy instance.
+	_lock *sync.Mutex
 
-// Singleton instance representing the strategy adopted from the DFaaS agent
-var _strategyInstance Strategy
+	// Singleton instance representing the active strategy.
+	_strategyInstance Strategy
+)
 
-// Initialize initializes this package
+// Initialize sets up the package. Warning: call this function only once!
 func Initialize(p2pHost host.Host, config config.Configuration) {
-	// Obtain the global logger object.
-	logger := logging.Logger()
-
 	_p2pHost = p2pHost
 	_config = config
 	_lock = &sync.Mutex{}
 
 	switch _config.Strategy {
 	default:
-		logger.Warn("No loadbalancer strategy found, using RecalcStrategy by default")
+		logging.Logger().Warn("No loadbalancer strategy found, using RecalcStrategy by default")
 		fallthrough
 	case constants.RecalcStrategy:
 		_strategyFactory = &recalcStrategyFactory{}
@@ -54,26 +61,25 @@ func Initialize(p2pHost host.Host, config config.Configuration) {
 	}
 }
 
-//////////////////// PUBLIC STRUCT TYPES ////////////////////
-
-// Strategy interface represents a generic strategy.
-// Every new strategy for the agent must implement this interface.
+// Strategy interface represents a generic strategy. Every new strategy for the
+// agent must implement this interface.
 type Strategy interface {
-	// Method which executes the strategy
+	// RunStrategy executes the strategy loop. Warning: this function runs an
+	// infinite loop and should not return, except in case of errors or at
+	// termination.
 	RunStrategy() error
-	// Method called when a message is received from a peer
+
+	// OnReceives is called each time a message is received from a peer.
 	OnReceived(msg *pubsub.Message) error
 }
 
-//////////////////// PUBLIC METHODS ////////////////////
-
 // GetStrategyInstance returns the singleton Strategy instance.
-// In a critical section checks if the strategy is already instantiated and returns it.
-// If instance is nil, creates a new Strategy instance using the createStrategy method
-// of the strategy factory
 func GetStrategyInstance() (Strategy, error) {
 	var err error
 
+	// In a critical section checks if the strategy is already instantiated and
+	// returns it. If instance is nil, creates a new Strategy instance using the
+	// createStrategy method of the strategy factory
 	_lock.Lock()
 	defer _lock.Unlock()
 

--- a/dfaasagent/agent/loadbalancer/nodemarginstrategy.go
+++ b/dfaasagent/agent/loadbalancer/nodemarginstrategy.go
@@ -166,7 +166,7 @@ func (strategy *NodeMarginStrategy) RunStrategy() error {
 			return err
 		}
 
-		httpserver.NmsSuccessIterations.Inc()
+		httpserver.StrategySuccessIterations.Inc()
 
 		millisNow = time.Now().UnixNano() / 1000000
 		millisSleep = millisInterval - (millisNow % millisInterval)

--- a/dfaasagent/agent/loadbalancer/nodemarginstrategy.go
+++ b/dfaasagent/agent/loadbalancer/nodemarginstrategy.go
@@ -98,6 +98,8 @@ func (strategy *NodeMarginStrategy) RunStrategy() error {
 	var ramUsage = make(map[string]float64)
 
 	for {
+		start := time.Now()
+
 		cpuUsage, err = ofpromq.QueryCPUusage(_config.RecalcPeriod)
 		if err != nil {
 			logger.Error("Failed to execute Prometheus QueryCPUusage query, skipping RunStrategy iteration ", err)
@@ -166,7 +168,10 @@ func (strategy *NodeMarginStrategy) RunStrategy() error {
 			return err
 		}
 
+		duration := time.Since(start)
+
 		httpserver.StrategySuccessIterations.Inc()
+		httpserver.StrategyIterationDuration.Set(duration.Seconds())
 
 		millisNow = time.Now().UnixNano() / 1000000
 		millisSleep = millisInterval - (millisNow % millisInterval)

--- a/dfaasagent/agent/loadbalancer/recalcstrategy.go
+++ b/dfaasagent/agent/loadbalancer/recalcstrategy.go
@@ -261,7 +261,7 @@ func (strategy *RecalcStrategy) recalcStep1() error {
 		} else {
 			margin = maxRate
 		}
-		logger.Debugf("Function %q: invocation rate=%f max rate=%d margin=%d", funcName, invocRate, maxRate, margin)
+		logger.Debugf("Function %q: invocation rate=%f max_rate=%d margin=%d", funcName, invocRate, maxRate, margin)
 
 		strategy.nodestbl.SafeExec(func(entries map[string]*nodestbl.EntryRecalc) error {
 			nNodes := uint(0)

--- a/dfaasagent/agent/loadbalancer/recalcstrategy.go
+++ b/dfaasagent/agent/loadbalancer/recalcstrategy.go
@@ -8,16 +8,17 @@ package loadbalancer
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/bcicen/go-haproxy"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/pkg/errors"
 
 	"github.com/unimib-datAI/dfaas/dfaasagent/agent/communication"
 	"github.com/unimib-datAI/dfaas/dfaasagent/agent/constants"
 	"github.com/unimib-datAI/dfaas/dfaasagent/agent/hacfgupd"
+	"github.com/unimib-datAI/dfaas/dfaasagent/agent/httpserver"
 	"github.com/unimib-datAI/dfaas/dfaasagent/agent/infogath/hasock"
 	"github.com/unimib-datAI/dfaas/dfaasagent/agent/infogath/offuncs"
 	"github.com/unimib-datAI/dfaas/dfaasagent/agent/infogath/ofpromq"
@@ -26,20 +27,22 @@ import (
 	"github.com/unimib-datAI/dfaas/dfaasagent/agent/utils/p2phostutils"
 )
 
-// In this file is implemented the Recalc strategy
+// This file contains the implementation of the Recalc strategy.
 
 // Struct representing a RecalcStrategy instance, which implements the Strategy interface
+
+// RecalcStrategy represent a Recalc strategy instance.
+//
+// As it implements the Strategy interface, it has the RunStrategy() and
+// OnReceived() methods.
+//
+// As an internal detail, the strategy action is divided into two steps.
 type RecalcStrategy struct {
 	hacfgupdater  hacfgupd.Updater
 	nodestbl      *nodestbl.TableRecalc
 	offuncsClient *offuncs.Client
-	recalc        recalc
-	it            int // = 0 // Number of agent loop iterations
-}
 
-// Private struct containing variables specific to the recalc algorithm, which
-// need to be shared amongst the two recalc steps
-type recalc struct {
+	// The following variables are specific to the Recalc algorithm.
 	nodeIDs         []peer.ID                     // IDs of the connected p2p nodes
 	stats           []*haproxy.Stat               // HAProxy stats
 	funcs           map[string]uint               // Our OpenFaaS functions with dfaas.maxrate limits
@@ -55,27 +58,37 @@ type recalc struct {
 	// For each function, the value is true if the node is currently in overload
 	// mode (req/s >= maxrate), false if underload
 	overloads map[string]bool
+
+	it int // = 0 // Number of agent loop iterations
 }
 
-//////////////////// PUBLIC FUNCTIONS FOR RECALC ////////////////////
-
 // RunStrategy handles the periodic execution of the recalculation function. It
-// should run in a goroutine
+// should run in a goroutine.
 func (strategy *RecalcStrategy) RunStrategy() error {
-	// Obtain the global logger object
 	logger := logging.Logger()
 
 	var millisNow, millisSleep int64
-	var err error
 
 	if _config.RecalcPeriod == 0 {
 		logger.Warn("Given RecalcPeriod must be a positive time duration, using 1 minute by default")
 		_config.RecalcPeriod = 1 * time.Minute
 	}
 
+	// Set the interval to wait after a failed recalculation attempt. This is
+	// used for both step 1 and step 2 error recovery.
+	failedInterval := 5 * time.Second
+
+	// Calculate the interval (in milliseconds) at which the recalculation
+	// should occur.
 	millisInterval := int64(_config.RecalcPeriod / time.Millisecond)
+
+	// Calculate half of the interval (in milliseconds). Used for timing the
+	// second recalculation step to occur halfway between intervals.
 	millisIntervalHalf := millisInterval / 2
 
+	// The Recalc strategy code is divided into two steps: the first gathers
+	// data and updates the local state, and the second calculates the new
+	// weights and updates the HAProxy configuration.
 	for {
 		millisNow = time.Now().UnixNano() / 1000000
 		millisSleep = millisInterval - (millisNow % millisInterval)
@@ -83,8 +96,8 @@ func (strategy *RecalcStrategy) RunStrategy() error {
 
 		if err := strategy.recalcStep1(); err != nil {
 			logger.Error("Failed Recalc step 1, skipping RunStrategy iteration ", err)
-			logger.Warn("Waiting 5 second before retrying RunStrategy")
-			time.Sleep(5 * time.Second)
+			logger.Warnf("Waiting %v before retrying RunStrategy", failedInterval.Seconds())
+			time.Sleep(failedInterval)
 			continue
 		}
 
@@ -92,116 +105,95 @@ func (strategy *RecalcStrategy) RunStrategy() error {
 		millisSleep = millisInterval - ((millisNow + millisIntervalHalf) % millisInterval)
 		time.Sleep(time.Duration(millisSleep) * time.Millisecond)
 
-		err = strategy.recalcStep2()
-		if err != nil {
-			return err
+		if err := strategy.recalcStep2(); err != nil {
+			logger.Error("Failed Recalc step 2, skipping RunStrategy iteration ", err)
+			logger.Warnf("Waiting %v before retrying RunStrategy", failedInterval.Seconds())
+			time.Sleep(failedInterval)
+			continue
 		}
+
+		httpserver.StrategySuccessIterations.Inc()
 	}
 }
 
-// OnReceived should be executed every time a message from a peer is received
+// OnReceived is executed every time a message from a peer is received.
 func (strategy *RecalcStrategy) OnReceived(msg *pubsub.Message) error {
 	var msgForType struct{ MsgType string }
-	err := json.Unmarshal(msg.GetData(), &msgForType)
-	if err != nil {
-		return errors.Wrap(err, "Error while deserializing a message from the PubSub subscription")
+	if err := json.Unmarshal(msg.GetData(), &msgForType); err != nil {
+		return fmt.Errorf("Error while deserializing a message from the PubSub subscription: %w", err)
 	}
 
 	switch msgForType.MsgType {
 	case StrMsgTextType:
 		var objMsg MsgText
-		err := json.Unmarshal(msg.GetData(), &objMsg)
-		if err != nil {
-			return errors.Wrap(err, "Error while deserializing a message from the PubSub subscription")
+		if err := json.Unmarshal(msg.GetData(), &objMsg); err != nil {
+			return fmt.Errorf("Error while deserializing a message from the PubSub subscription: %w", err)
 		}
 
 		processMsgText(msg.GetFrom().String(), &objMsg)
 	case StrMsgNodeInfoTypeRecalc:
 		var objMsg MsgNodeInfoRecalc
-		err := json.Unmarshal(msg.GetData(), &objMsg)
-		if err != nil {
-			return errors.Wrap(err, "Error while deserializing a message from the PubSub subscription")
+		if err := json.Unmarshal(msg.GetData(), &objMsg); err != nil {
+			return fmt.Errorf("Error while deserializing a message from the PubSub subscription: %w", err)
 		}
 
 		strategy.processMsgNodeInfoRecalc(msg.GetFrom().String(), &objMsg)
+	default:
+		logging.Logger().Warnf("Unrecognized message type %q", msgForType.MsgType)
 	}
 
 	return nil
 }
 
-//////////////////// PRIVATE FUNCTIONS FOR RECALC ////////////////////
-
 func (strategy *RecalcStrategy) recalcStep1() error {
 	var err error
 	logger := logging.Logger()
-	millisNow := time.Now().UnixNano() / 1000000
-	logger.Debugf("#################### RECALC: STEP 1 (UnixMillis %d) ####################", millisNow)
 
-	//////////////////// EXAMPLE TEXT MESSAGE ////////////////////
+	// Get list of connected nodes.
+	strategy.nodeIDs = p2phostutils.GetConnNodeIDsUniq(_p2pHost)
+	debugConnectedNodes(strategy.nodeIDs)
 
-	//err := communication.MarshAndPublish(MsgText{
-	//	MsgType: StrMsgTextType,
-	//	Text:    "I'm alive!",
-	//})
-	//if err != nil {
-	//	return err
-	//}
-
-	//////////////////// GET LIST OF CONNECTED NODES ////////////////////
-
-	strategy.recalc.nodeIDs = p2phostutils.GetConnNodeIDsUniq(_p2pHost)
-	debugConnectedNodes(strategy.recalc.nodeIDs)
-
-	//////////////////// GATHER HAPROXY STATS ////////////////////
-
-	//_recalc.stats, err = _hasockClient.Stats()
-	//if err != nil {
-	//	return errors.Wrap(err, "Error while gathering HAProxy stats from socket")
-	//}
-	//debugHAProxyStats(_recalc.stats)
-
-	//////////////////// GATHER INFO ABOUT OPENFAAS FUNCTIONS ////////////////////
-
-	strategy.recalc.funcs, err = strategy.offuncsClient.GetFuncsWithMaxRates()
+	// Get stats about OpenFaaS functions.
+	strategy.funcs, err = strategy.offuncsClient.GetFuncsWithMaxRates()
 	if err != nil {
-		return errors.Wrap(err, "get functions info from OpenFaaS")
+		return fmt.Errorf("get functions info from OpenFaaS: %w", err)
 	}
-	debugFuncs(strategy.recalc.funcs)
+	debugFuncs(strategy.funcs)
 
-	//////////////////// GATHER INFO FROM HAPROXY STICKTABLES st_users_func_* ////////////////////
-
-	strategy.recalc.userRates = map[string]float64{}
-
-	for funcName := range strategy.recalc.funcs {
+	// Get stats from HAProxy stick tables (st_users_func_*).
+	strategy.userRates = map[string]float64{}
+	for funcName := range strategy.funcs {
 		stName := fmt.Sprintf("st_users_func_%s", funcName)
 		stContent, err := hasock.ReadStickTable(stName)
 
 		if err != nil {
-			errWrap := errors.Wrap(err, "Error while reading the stick-table \""+stName+"\" from the HAProxy socket")
-			logger.Error(errWrap)
-			logger.Warn("Not changing userRates for stick-table \"" + stName + "\" but this should be ok")
-		} else {
-			for _, stEntry := range stContent {
-				// There should be only one line, with key "80", which is the port of the HAProxy frontend
-				strategy.recalc.userRates[funcName] = float64(stEntry.HTTPReqCnt) / float64(_config.RecalcPeriod/time.Second) * 2
-				// Note: the whole formula is multiplied by two at the end because we know we restarted HAProxy at the end of recalcStep2
-			}
+			logger.Error(fmt.Errorf("Error while reading the stick-table %q from the HAProxy socket: %w", stName, err))
+			logger.Warnf("Not changing userRates for stick-table %q but this should be ok", stName)
+			continue
+		}
+
+		for _, stEntry := range stContent {
+			// There should be only one line, with key "80", which is the port
+			// of the HAProxy frontend
+			//
+			// Note: the whole formula is multiplied by two at the end because
+			// we know we restarted HAProxy at the end of recalcStep2
+			strategy.userRates[funcName] = float64(stEntry.HTTPReqCnt) / float64(_config.RecalcPeriod/time.Second) * 2
 		}
 
 		debugStickTable(stName, stContent)
 	}
-	debugHAProxyUserRates(strategy.recalc.userRates)
+	debugHAProxyUserRates(strategy.userRates)
 
-	//////////////////// [NEW] GATHER INFO FROM HAPROXY STICKTABLES st_local_func_* ////////////////////
-
-	for funcName := range strategy.recalc.funcs {
+	// Get stats from HAProxy stick tables (st_local_func_*).
+	for funcName := range strategy.funcs {
 		stName := fmt.Sprintf("st_local_func_%s", funcName)
 		stContent, err := hasock.ReadStickTable(stName)
 
 		if err != nil {
-			errWrap := errors.Wrap(err, "Error while reading the stick-table \""+stName+"\" from the HAProxy socket")
-			logger.Error(errWrap)
-			logger.Warn("Not changing local rates for stick-table \"" + stName + "\" but this should be ok")
+			logger.Error(fmt.Errorf("Error while reading the stick-table %q from the HAProxy socket: %w", stName, err))
+			logger.Warnf("Not changing local rates for stick-table %q but this should be ok", stName)
+			continue
 		}
 
 		debugStickTable(stName, stContent)
@@ -209,13 +201,13 @@ func (strategy *RecalcStrategy) recalcStep1() error {
 
 	//////////////////// [NEW] GATHER INFO FOR STICKTABLES OF DATA FROM OTHER NODES ////////////////////
 	/*
-		for funcName := range _recalc.funcs {
-			for _, nodeID := range _recalc.nodeIDs {
+		for funcName := range strategy.funcs {
+			for _, nodeID := range strategy.nodeIDs {
 				stName := fmt.Sprintf("st_other_node_%s_%s", funcName, nodeID.String())
 				stContent, err := hasock.ReadStickTable(&_hasockClient, stName)
 
 				if err != nil {
-					errWrap := errors.Wrap(err, "Error while reading the stick-table \""+stName+"\" from the HAProxy socket")
+					errWrap := fmt.Errorf("Error while reading the stick-table \"%s\" from the HAProxy socket: %w", stName, err)
 					logger.Error(errWrap)
 					logger.Warn("Not changing other nodes rates for stick-table \"" + stName + "\" but this should be ok")
 				}
@@ -224,85 +216,78 @@ func (strategy *RecalcStrategy) recalcStep1() error {
 			}
 		}
 	*/
-	//////////////////// GATHER INFO FROM PROMETHEUS ////////////////////
 
-	strategy.recalc.afet, err = ofpromq.QueryAFET(_config.RecalcPeriod)
+	// Get info from Prometheus.
+	strategy.afet, err = ofpromq.QueryAFET(_config.RecalcPeriod)
 	if err != nil {
-		return errors.Wrap(err, "Error while execting Prometheus query")
+		return fmt.Errorf("Error while execting Prometheus query: %w", err)
 	}
-	debugPromAFET(_config.RecalcPeriod, strategy.recalc.afet)
+	debugPromAFET(_config.RecalcPeriod, strategy.afet)
 
-	strategy.recalc.invoc, err = ofpromq.QueryInvoc(_config.RecalcPeriod)
+	strategy.invoc, err = ofpromq.QueryInvoc(_config.RecalcPeriod)
 	if err != nil {
-		return errors.Wrap(err, "Error while executing Prometheus query")
+		return fmt.Errorf("Error while executing Prometheus query: %w", err)
 	}
-	debugPromInvoc(_config.RecalcPeriod, strategy.recalc.invoc)
+	debugPromInvoc(_config.RecalcPeriod, strategy.invoc)
 
-	strategy.recalc.serviceCount, err = ofpromq.QueryServiceCount()
+	strategy.serviceCount, err = ofpromq.QueryServiceCount()
 	if err != nil {
-		return errors.Wrap(err, "Error while executing Prometheus query")
+		return fmt.Errorf("Error while executing Prometheus query: %w", err)
 	}
-	debugPromServiceCount(strategy.recalc.serviceCount)
+	debugPromServiceCount(strategy.serviceCount)
 
-	strategy.recalc.cpuUsage, err = ofpromq.QueryCPUusage(_config.RecalcPeriod)
+	strategy.cpuUsage, err = ofpromq.QueryCPUusage(_config.RecalcPeriod)
 	if err != nil {
-		return errors.Wrap(err, "Error while executing Prometheus query")
+		return fmt.Errorf("Error while executing Prometheus query: %w", err)
 	}
-	debugPromCPUusage(_config.RecalcPeriod, strategy.recalc.cpuUsage)
+	debugPromCPUusage(_config.RecalcPeriod, strategy.cpuUsage)
 
-	strategy.recalc.ramUsage, err = ofpromq.QueryRAMusage(_config.RecalcPeriod)
+	strategy.ramUsage, err = ofpromq.QueryRAMusage(_config.RecalcPeriod)
 	if err != nil {
-		return errors.Wrap(err, "Error while executing Prometheus query")
+		return fmt.Errorf("Error while executing Prometheus query: %w", err)
 	}
-	debugPromRAMusage(_config.RecalcPeriod, strategy.recalc.ramUsage)
+	debugPromRAMusage(_config.RecalcPeriod, strategy.ramUsage)
 
-	if len(strategy.recalc.funcs) > 0 {
-		// Get function's name as a slice.
-		funcNames := make([]string, len(strategy.recalc.funcs))
+	// Also get specific info for each function.
+	if len(strategy.funcs) > 0 {
+		funcNames := make([]string, len(strategy.funcs))
 		i := 0
-		for k := range strategy.recalc.funcs {
+		for k := range strategy.funcs {
 			funcNames[i] = k
 			i++
 		}
 
-		strategy.recalc.perFuncCpuUsage, err = ofpromq.QueryCPUusagePerFunction(_config.RecalcPeriod, funcNames)
+		strategy.perFuncCpuUsage, err = ofpromq.QueryCPUusagePerFunction(_config.RecalcPeriod, funcNames)
 		if err != nil {
-			return errors.Wrap(err, "Error while executing Prometheus query")
+			return fmt.Errorf("Error while executing Prometheus query: %w", err)
 		}
-		debugPromCPUusagePerFunction(_config.RecalcPeriod, strategy.recalc.perFuncCpuUsage)
+		debugPromCPUusagePerFunction(_config.RecalcPeriod, strategy.perFuncCpuUsage)
 
-		strategy.recalc.perFuncRamUsage, err = ofpromq.QueryRAMusagePerFunction(_config.RecalcPeriod, funcNames)
+		strategy.perFuncRamUsage, err = ofpromq.QueryRAMusagePerFunction(_config.RecalcPeriod, funcNames)
 		if err != nil {
-			return errors.Wrap(err, "Error while executing Prometheus query")
+			return fmt.Errorf("Error while executing Prometheus query: %w", err)
 		}
-		debugPromRAMusagePerFunction(_config.RecalcPeriod, strategy.recalc.perFuncRamUsage)
+		debugPromRAMusagePerFunction(_config.RecalcPeriod, strategy.perFuncRamUsage)
 	}
 
-	//////////////////// OVERLOAD / UNDERLOAD MODE DECISION ////////////////////
-
-	strategy.recalc.overloads = map[string]bool{}
-
-	for funcName, maxRate := range strategy.recalc.funcs {
-		logger.Debugf("Computing if %s function is on overload", funcName)
-		invocRate, present := strategy.recalc.userRates[funcName]
+	// Set overload/underload state for each function.
+	strategy.overloads = map[string]bool{}
+	for funcName, maxRate := range strategy.funcs {
+		invocRate, present := strategy.userRates[funcName]
 
 		if !present || invocRate < float64(maxRate) {
-			strategy.recalc.overloads[funcName] = false
+			strategy.overloads[funcName] = false
 		} else {
-			strategy.recalc.overloads[funcName] = true
+			strategy.overloads[funcName] = true
 		}
+
+		logger.Debugf("Function %q overloaded: %t", funcName, strategy.overloads[funcName])
 	}
-	debugOverloads(strategy.recalc.overloads) // Debug purpose.
 
-	strategy.it++
-
-	//////////////////// LIMITS AND WEIGHTS CALCULATIONS ////////////////////
-
-	for funcName, ovrld := range strategy.recalc.overloads {
-		logger.Debugf("Calculating limits and weights for %s function", funcName)
-		if ovrld {
-			// Set all funcData.LimitIn to zero for this function
-			logger.Debugf("%s function is on overload! Setting LimitIn to 0", funcName)
+	// Calculate limits and weights.
+	for funcName, overloaded := range strategy.overloads {
+		if overloaded {
+			logger.Debugf("Function %q is on overloaded! Setting LimitIn to 0", funcName)
 			strategy.nodestbl.SafeExec(func(entries map[string]*nodestbl.EntryRecalc) error {
 				for _, entry := range entries {
 					funcData, present := entry.FuncsData[funcName]
@@ -310,101 +295,70 @@ func (strategy *RecalcStrategy) recalcStep1() error {
 						funcData.LimitIn = 0
 					}
 				}
-
 				return nil
 			})
+			continue
+		}
+
+		// If not overloaded, we calculate the rate margin.
+		invocRate, present := strategy.userRates[funcName]
+		maxRate := strategy.funcs[funcName]
+		var margin uint
+		if present {
+			margin = maxRate - uint(invocRate)
 		} else {
-			// Calculate the rate margin
-			logger.Debugf("Calculating rate margin for %s function", funcName)
-			invocRate, present := strategy.recalc.userRates[funcName]
-			maxRate := strategy.recalc.funcs[funcName]
-			logger.Debugf("%s function invocation rate is %f", funcName, invocRate)
-			logger.Debugf("%s function max rate is %d", funcName, maxRate)
-			var margin uint
-			if present {
-				margin = maxRate - uint(invocRate)
-			} else {
-				margin = maxRate
+			margin = maxRate
+		}
+		logger.Debugf("Function %q: invocation rate=%f max rate=%d margin=%d", funcName, invocRate, maxRate, margin)
+
+		strategy.nodestbl.SafeExec(func(entries map[string]*nodestbl.EntryRecalc) error {
+			nNodes := uint(0)
+			for _, entry := range entries {
+				funcData, present := entry.FuncsData[funcName]
+				if present {
+					funcData.NodeWeight = 0
+					nNodes++
+					logger.Debugf("Set Weight to 0 for %s function", funcName)
+				}
 			}
-
-			logger.Debugf("%s function margin equal to %d", funcName, margin)
-
-			// Set all funcData.Weight to zero for this function, and set the
-			// LimitIn for each node
-			logger.Debugf("Setting Weight to 0 for %s function and setting LimitIn for each node", funcName)
-			strategy.nodestbl.SafeExec(func(entries map[string]*nodestbl.EntryRecalc) error {
-				nNodes := uint(0)
-
+			if nNodes > 0 {
+				limitIn := margin / nNodes
 				for _, entry := range entries {
 					funcData, present := entry.FuncsData[funcName]
 					if present {
-						// Weights represent likelihood of send a request toward i-th
-						// function instance.
-						// Considering that this function instance is labelled as "underload"
-						// it is not necessary to send request towards other nodes.
-						funcData.NodeWeight = 0
-						nNodes++
-						logger.Debugf("Set Weight to 0 for %s function", funcName)
+						funcData.LimitIn = float64(limitIn)
+						logger.Debugf("Set LiminIn to %f for %s function", funcData.LimitIn, funcName)
 					}
 				}
-
-				// Note: if nNodes == 0, it means that (for now) i am the only
-				// one to have this function, so i don't have to set the LimitIn
-				// for anyone because no one needs it. Note also that the
-				// nodestbl.SetReceivedValues() function sets the LimitIn to
-				// zero, so not setting it here is ok
-
-				if nNodes > 0 {
-					limitIn := margin / nNodes // Equal distribution! May be
-					// replaced in the future with a more efficient algorithm
-
-					for _, entry := range entries {
-						funcData, present := entry.FuncsData[funcName]
-						if present {
-							funcData.LimitIn = float64(limitIn)
-							logger.Debugf("Set LiminIn to %f for %s function", funcData.LimitIn, funcName)
-						}
-					}
-				}
-
-				return nil
-			})
-		}
+			}
+			return nil
+		})
 	}
 
-	//////////////////// PRINT CONTENT OF NODESTBL ////////////////////
-
+	// Print content of NodeStbl.
 	strategy.nodestbl.SafeExec(func(entries map[string]*nodestbl.EntryRecalc) error {
 		debugNodesTblContent(entries)
 		return nil
 	})
 
-	//////////////////// P2P MESSAGES PUBLISHING ////////////////////
-
+	// Publish messages on p2p network.
 	limits := map[string]map[string]float64{}
-
 	strategy.nodestbl.SafeExec(func(entries map[string]*nodestbl.EntryRecalc) error {
-		for _, nodeID := range strategy.recalc.nodeIDs {
+		for _, nodeID := range strategy.nodeIDs {
 			strNodeID := nodeID.String()
-
 			entry, present := entries[strNodeID]
 			if present {
-				// If this node has sent me some messages before, i send him the
-				// limits according to the nodestbl
 				limits[strNodeID] = map[string]float64{}
 				for funcName, funcData := range entry.FuncsData {
 					limits[strNodeID][funcName] = funcData.LimitIn
 				}
 			} else {
-				// If this node has not sent me anything before, i send him all
-				// the functions i have, but with all limits set to zero
 				limits[strNodeID] = map[string]float64{}
-				for funcName := range strategy.recalc.funcs {
+				for funcName := range strategy.funcs {
 					limits[strNodeID][funcName] = 0
 				}
 			}
 		}
-
 		return nil
 	})
 
@@ -420,71 +374,63 @@ func (strategy *RecalcStrategy) recalcStep1() error {
 	if err != nil {
 		return err
 	}
-	//////////////////// IF EVERYTHING OK, RETURN NIL ////////////////////
-
 	return nil
 }
 
 func (strategy *RecalcStrategy) recalcStep2() error {
-	var err error
-	logger := logging.Logger()
-	millisNow := time.Now().UnixNano() / 1000000
-	logger.Debugf("#################### RECALC: STEP 2 (UnixMillis %d) ####################", millisNow)
-
-	//////////////////// CALC WEIGHTS FOR FUNCTIONS IN OVERLOAD MODE ////////////////////
-
-	for funcName, ovrld := range strategy.recalc.overloads {
-		if ovrld {
-			// Calculate the weights for this function
-			strategy.nodestbl.SafeExec(func(entries map[string]*nodestbl.EntryRecalc) error {
-				totLimitsOut := float64(0)
-
-				// Loop on all node in _nodestbl, check if that node
-				// has this function running; if is present sum the amount of
-				// req/sec forwardable to this node.
-				for _, entry := range entries {
-					funcData, present := entry.FuncsData[funcName]
-					if present {
-						totLimitsOut += funcData.LimitOut
-					}
-				}
-
-				if totLimitsOut <= 0 {
-					// If no node is available to help me with this function, i
-					// set totLimitsOut to 1, only to avoid division by zero
-					// problems. All the weights will be zero anyway
-					totLimitsOut = 1
-				}
-
-				// Loop on all all node in _nodestbl, if function funcName is present in this node
-				// that is in "oveload" state, is present also in i-th node, calculate
-				// weight for the instance of function in i-th node.
-				// Weight is based on LimitOut (number of req/sec forwardable to this node)
-				// divided by total forwardable request.
-				// All multiplied by 100, that is the sum of weights; this op allow to
-				// express weights as the percentage of requests forwarded by this node to
-				// other functions that runs on other nodes.
-				for _, entry := range entries {
-					funcData, present := entry.FuncsData[funcName]
-					if present {
-						funcData.NodeWeight = uint(funcData.LimitOut * constants.HAProxyMaxWeight / totLimitsOut)
-					}
-				}
-
-				return nil
-			})
+	// Calculate weights for functions in overloaded mode.
+	for funcName, overloaded := range strategy.overloads {
+		if !overloaded {
+			continue
 		}
+
+		// Calculate the weights for this function.
+		strategy.nodestbl.SafeExec(func(entries map[string]*nodestbl.EntryRecalc) error {
+			totLimitsOut := float64(0)
+
+			// Loop on all node in _nodestbl, check if that node
+			// has this function running; if is present sum the amount of
+			// req/sec forwardable to this node.
+			for _, entry := range entries {
+				funcData, present := entry.FuncsData[funcName]
+				if present {
+					totLimitsOut += funcData.LimitOut
+				}
+			}
+
+			if totLimitsOut <= 0 {
+				// If no node is available to help me with this function, i
+				// set totLimitsOut to 1, only to avoid division by zero
+				// problems. All the weights will be zero anyway
+				totLimitsOut = 1
+			}
+
+			// Loop on all all node in _nodestbl, if function funcName is present in this node
+			// that is in "oveload" state, is present also in i-th node, calculate
+			// weight for the instance of function in i-th node.
+			// Weight is based on LimitOut (number of req/sec forwardable to this node)
+			// divided by total forwardable request.
+			// All multiplied by 100, that is the sum of weights; this op allow to
+			// express weights as the percentage of requests forwarded by this node to
+			// other functions that runs on other nodes.
+			for _, entry := range entries {
+				funcData, present := entry.FuncsData[funcName]
+				if present {
+					funcData.NodeWeight = uint(funcData.LimitOut * constants.HAProxyMaxWeight / totLimitsOut)
+				}
+			}
+
+			return nil
+		})
 	}
 
-	//////////////////// PRINT CONTENT OF NODESTBL ////////////////////
-
+	// Print content of nodestbl.
 	strategy.nodestbl.SafeExec(func(entries map[string]*nodestbl.EntryRecalc) error {
 		debugNodesTblContent(entries)
 		return nil
 	})
 
-	//////////////////// UPDATE HAPROXY CONFIGURATION ////////////////////
-
+	// Update HAProxy config.
 	strMyself := _p2pHost.ID().String()
 
 	var hacfg *HACfgRecalc
@@ -495,22 +441,19 @@ func (strategy *RecalcStrategy) recalcStep2() error {
 			_config.OpenFaaSPort,
 			_config.RecalcPeriod,
 			entries,
-			strategy.recalc.funcs,
+			strategy.funcs,
 		)
 		return nil
 	})
 
-	err = strategy.updateHAProxyConfig(hacfg)
-	if err != nil {
-		return err
+	if err := strategy.updateHAProxyConfig(hacfg); err != nil {
+		return fmt.Errorf("Updating HAProxy config: %w", err)
 	}
-
-	//////////////////// IF EVERYTHING OK, RETURN NIL ////////////////////
 
 	return nil
 }
 
-// processMsgNodeInfoRecalc processes a node info message received from pubsub
+// processMsgNodeInfoRecalc processes a node info message received from pubsub.
 func (strategy *RecalcStrategy) processMsgNodeInfoRecalc(sender string, msg *MsgNodeInfoRecalc) error {
 	logger := logging.Logger()
 	myself := _p2pHost.ID().String()
@@ -520,80 +463,77 @@ func (strategy *RecalcStrategy) processMsgNodeInfoRecalc(sender string, msg *Msg
 	}
 
 	if logging.GetDebugMode() {
-		logger.Debugf("Received node info message from node %s", sender)
+		var debugBuffer strings.Builder
+		debugBuffer.WriteString(fmt.Sprintf("Received node info message from node %s\n", sender))
 		for _nodeID, _limits := range msg.FuncLimits {
-			logger.Debugf("Functions limits for node %s:", _nodeID)
+			debugBuffer.WriteString(fmt.Sprintf("Functions limits for node %s:\n", _nodeID))
 			for funcName := range _limits {
-				logger.Debugf("	Function %s LimitOut: %f", funcName, _limits[funcName])
+				debugBuffer.WriteString(fmt.Sprintf("\tFunction %s LimitOut: %f\n", funcName, _limits[funcName]))
 			}
 		}
+		logger.Debug(debugBuffer.String())
 	}
 
-	// Note: if the sender node do not "know" us (we aren't in his FuncLimits) we just ignore his message
+	// Note: if the sender node do not "know" us (we aren't in his FuncLimits)
+	// we just ignore his message.
 	funcLimits, present := msg.FuncLimits[myself]
-	if present {
-		logger.Debugf("Setting received values for node %s into table", sender)
-		return strategy.nodestbl.SafeExec(func(entries map[string]*nodestbl.EntryRecalc) error {
-			// If the message arrives from a sender node with ID nodeID that is
-			// not present in _nodesbl yet, it is added to the table.
-			_, present := entries[sender]
+	if !present {
+		return nil
+	}
+	err := strategy.nodestbl.SafeExec(func(entries map[string]*nodestbl.EntryRecalc) error {
+		var debugBuffer strings.Builder
+		debugBuffer.WriteString(fmt.Sprintf("Setting received values for node %s into table\n", sender))
+
+		// If the message arrives from a sender node with ID nodeID that is not
+		// present in _nodesbl yet, it is added to the table.
+		_, present := entries[sender]
+		if !present {
+			entries[sender] = &nodestbl.EntryRecalc{
+				FuncsData: map[string]*nodestbl.FuncData{},
+			}
+			debugBuffer.WriteString(fmt.Sprintf("Node %s was not present and has been added to the table\n", sender))
+		}
+
+		entries[sender].TAlive = time.Now()
+
+		entries[sender].HAProxyHost = msg.HAProxyHost
+		entries[sender].HAProxyPort = msg.HAProxyPort
+
+		// Remove from my table the functions limits which are no more present
+		// in the new updated message.
+		debugBuffer.WriteString(fmt.Sprintf("Removing functions limits no more present in the received message from node %s\n", sender))
+		for funcName := range entries[sender].FuncsData {
+			_, present := funcLimits[funcName]
 			if !present {
-				entries[sender] = &nodestbl.EntryRecalc{
-					FuncsData: map[string]*nodestbl.FuncData{},
-				}
-				logger.Debugf("Node %s was not present and has been added to the table", sender)
+				delete(entries[sender].FuncsData, funcName)
+				debugBuffer.WriteString(fmt.Sprintf("%s function is no more present in the received message from node %s and has been removed\n", funcName, sender))
 			}
+		}
 
-			entries[sender].TAlive = time.Now()
-
-			entries[sender].HAProxyHost = msg.HAProxyHost
-			entries[sender].HAProxyPort = msg.HAProxyPort
-
-			// Remove from my table the functions limits which are no more present
-			// in the new updated message
-			logger.Debugf("Removing functions limits no more present in the received message from node %s", sender)
-			for funcName := range entries[sender].FuncsData {
-				// Once this routine executed a message from another node of the
-				// p2p net has been received.
-				// If I (and I am the receiver node) stored in _nodestbl functions
-				// that are not more present in sender node, identified by the fact
-				// that they are not more present in received message, I can remove them
-				// from my local table.
-				_, present := funcLimits[funcName]
-				if !present {
-					delete(entries[sender].FuncsData, funcName)
-					logger.Debugf("%s function is no more present in the received message from node %s and has been removed", funcName, sender)
+		// Update the functions limits with the received values (also add new
+		// functions which weren't present before).
+		debugBuffer.WriteString(fmt.Sprintf("Updating functions limits with received values from node %s\n", sender))
+		for funcName, limit := range funcLimits {
+			_, present := entries[sender].FuncsData[funcName]
+			if present {
+				entries[sender].FuncsData[funcName].LimitOut = limit
+				debugBuffer.WriteString(fmt.Sprintf("Updated LimitOut to %f for %s function of node %s\n", limit, funcName, sender))
+			} else {
+				entries[sender].FuncsData[funcName] = &nodestbl.FuncData{
+					LimitIn:    0,
+					LimitOut:   limit,
+					NodeWeight: 0,
 				}
+				debugBuffer.WriteString(fmt.Sprintf("Set LimitOut to %f, LimitIn to 0 and NodeWeight to 0 for %s function of node %s\n", limit, funcName, sender))
 			}
+		}
 
-			// Update the functions limits with the received values (also add new
-			// functions which weren't present before)
-			logger.Debugf("Updating functions limits with received values from node %s", sender)
-			for funcName, limit := range funcLimits {
-				_, present := entries[sender].FuncsData[funcName]
-				if present {
-					// For each function received by sender node, updates
-					// corrisponding line of _nodestbl table.
-					// If entry for sender node is present, updates LimitOut
-					// for that node with received limit.
-					// LimitOut means number of req/sec that I can fwd
-					// toward this node.
-					// Note: this LimitOut is updated on the base of LimitIn
-					// for this function received by i-th node (sender).
-					entries[sender].FuncsData[funcName].LimitOut = limit
-					logger.Debugf("Updated LimitOut to %f for %s function of node %s", limit, funcName, sender)
-				} else {
-					entries[sender].FuncsData[funcName] = &nodestbl.FuncData{
-						LimitIn:    0,
-						LimitOut:   limit,
-						NodeWeight: 0,
-					}
-					logger.Debugf("Set LimitOut to %f, LimitIn to 0 and NodeWeight to 0 for %s function of node %s", limit, funcName, sender)
-				}
-			}
+		logger.Debug(debugBuffer.String())
 
-			return nil
-		})
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	return nil

--- a/dfaasagent/agent/loadbalancer/recalcstrategy.go
+++ b/dfaasagent/agent/loadbalancer/recalcstrategy.go
@@ -189,6 +189,8 @@ func (strategy *RecalcStrategy) recalcStep1() error {
 			// FIXME: The http_req_rate value is taken from the previous
 			// 1-second period, not averaged over the entire recalculation
 			// period. This is a known limitation of the current strategy.
+            //
+            // See: https://github.com/unimib-datAI/dfaas/issues/45
 			strategy.userRates[funcName] = float64(stEntry.HTTPReqRate)
 		}
 

--- a/dfaasagent/agent/loadbalancer/staticstrategy.go
+++ b/dfaasagent/agent/loadbalancer/staticstrategy.go
@@ -75,8 +75,7 @@ func (strategy *StaticStrategy) RunStrategy() error {
 			return fmt.Errorf("setting new weights: %w", err)
 		}
 
-		// TODO: Change the counter instance.
-		httpserver.NmsSuccessIterations.Inc()
+		httpserver.StrategySuccessIterations.Inc()
 
 		millisNow = time.Now().UnixNano() / 1000000
 		millisSleep = millisInterval - (millisNow % millisInterval)

--- a/dfaasagent/agent/loadbalancer/staticstrategy.go
+++ b/dfaasagent/agent/loadbalancer/staticstrategy.go
@@ -57,6 +57,8 @@ func (strategy *StaticStrategy) RunStrategy() error {
 	millisInterval := int64(_config.RecalcPeriod / time.Millisecond)
 
 	for {
+		start := time.Now()
+
 		if err := strategy.publishNodeInfo(); err != nil {
 			logger.Error("Failed to publish node info, skipping RunStrategy iteration ", err)
 			logger.Warn("Waiting 5 second before retrying RunStrategy")
@@ -74,8 +76,10 @@ func (strategy *StaticStrategy) RunStrategy() error {
 		if err = strategy.setProxyWeights(); err != nil {
 			return fmt.Errorf("setting new weights: %w", err)
 		}
+		duration := time.Since(start)
 
 		httpserver.StrategySuccessIterations.Inc()
+		httpserver.StrategyIterationDuration.Set(duration.Seconds())
 
 		millisNow = time.Now().UnixNano() / 1000000
 		millisSleep = millisInterval - (millisNow % millisInterval)

--- a/dfaasagent/agent/nodestbl/nodestblrecalc.go
+++ b/dfaasagent/agent/nodestbl/nodestblrecalc.go
@@ -58,12 +58,10 @@ func (tbl *TableRecalc) initTable() {
 
 	if tbl.entries == nil {
 		tbl.entries = map[string]*EntryRecalc{}
-		logger.Debug("Initialized table entries")
 	}
 
 	if tbl.mutex == nil {
 		tbl.mutex = &sync.Mutex{}
-		logger.Debug("Initialized table mutex")
 	}
 }
 

--- a/dfaasagent/agent/nodestbl/nodestblrecalc.go
+++ b/dfaasagent/agent/nodestbl/nodestblrecalc.go
@@ -54,8 +54,6 @@ type TableRecalc struct {
 
 // InitTable initializes a TableRecalc's fields if they are empty
 func (tbl *TableRecalc) initTable() {
-	logger := logging.Logger()
-
 	if tbl.entries == nil {
 		tbl.entries = map[string]*EntryRecalc{}
 	}

--- a/docs/agent-strategies.md
+++ b/docs/agent-strategies.md
@@ -60,13 +60,10 @@ The weights recalculation occurs at intervals defined by the
 
 The following metrics are collected and used:
 
+* List of connected nodes,
+* List of functions with associated max rate for the local node,
 * Function invocation rates (requests per second for each function),
-* CPU and RAM usage,
-* Average function execution times,
-* Node overload status,
-* Service count (active requests to functions per node),
-* Per-function CPU usage,
-* Per-function RAM usage.
+* Node overload status.
 
 The Recalc strategy uses the concept of **maxrate** (maximum requests per
 second) for each function to determine how many requests a node can handle for

--- a/k8s/docker/Dockerfile.agent
+++ b/k8s/docker/Dockerfile.agent
@@ -16,11 +16,15 @@ ENV CGO_ENABLED=0
 WORKDIR /usr/src/dfaasagent
 
 COPY dfaasagent/go.mod dfaasagent/go.sum ./
-RUN go mod download
+RUN go mod download -x
 
 COPY dfaasagent/ .
 
-RUN go build -v -o dfaasagent .
+# Cache Go modules and intermediate build files to speed up subsequent
+# compilations.
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -v -o dfaasagent .
 
 # Stage 2: Create a minimal image using Alpine.
 FROM alpine:3.22

--- a/k8s/docker/Dockerfile.agent
+++ b/k8s/docker/Dockerfile.agent
@@ -16,7 +16,7 @@ ENV CGO_ENABLED=0
 WORKDIR /usr/src/dfaasagent
 
 COPY dfaasagent/go.mod dfaasagent/go.sum ./
-RUN go mod download -x
+RUN go mod download
 
 COPY dfaasagent/ .
 

--- a/setup_playbook.yaml
+++ b/setup_playbook.yaml
@@ -123,7 +123,7 @@
     - name: Install Helm charts
       block:
         - name: Install HAProxy on K3S
-          ansible.builtin.command: helm install haproxy haproxytech/haproxy --version 1.25.0 --values k8s/charts/values-haproxy.yaml
+          ansible.builtin.command: helm install haproxy haproxytech/haproxy --version 1.26.1 --values k8s/charts/values-haproxy.yaml
           args:
             chdir: "{{ playbook_dir }}"
 


### PR DESCRIPTION
This pull request contains four changes:

1. A new exported Prometheus metric for all strategies: `dfaas_agent_strategy_iteration_duration_seconds`.
2. A partial fix to the Recalc strategy for retrieving request rates from the HAProxy stick table (see #45).
3. Adds and refines documentation on strategies, with a focus on Recalc.
4. Speeds up the agent image build time.